### PR TITLE
Added custom port support for callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The final endpoint is '/execute', this endpoint is used to POST a request for a 
 
 ## Configuring the runner
 
-When testing the runner with rodent, the runner will need to be configured to send the callbacks to the IP address or hostname of the system where rodent is being executed.  It should be a simple case of running the trento runner with the command line arguments `runner start --callbacks-url <IP or hostname of rodent>`.
+When testing the runner with rodent, the runner will need to be configured to send the callbacks to the IP address or hostname of the system where rodent is being executed.  It should be a simple case of running the trento runner with the command line arguments `runner start --callbacks-url <IP or hostname of rodent>`.  If running a custom callback port (anything other than 8000) then the runner will need to be passed for full URL, for example if the callback port needs to be 4000 and the IP address of rodent is 172.16.1.5 the runner command should be `runner start --callbacks-url http://172.16.1.5:4000/api/runner/callback`
 
 ## Commands
 
@@ -55,13 +55,14 @@ The global flag `runner` must always be set so that rodent knows which runner to
 
 # Perform a single check.  Now the runner needs to target a host and a provider type.  The following example shows testing a system with the hostname 'test01' running on Azure.
 # Here the -t flag is used for the Target.  The -p flag sets the provider and -c sets the check ID
-./rodent -r test-runner ExecuteCheck -t test01 -p azure -c 21FCA6
+# Also, the callback port is specified as 4000 using the --callbackPort flag, if the callback port required is default 8000 this flag can be omitted.
+./rodent -r test-runner ExecuteCheck -t test01 -p azure -c 21FCA6 --callbackPort 4000
 # Output will be something like
 # INFO[0022] CheckID 21FCA6 state is 'passing'
 # Note that running CheckReady, CheckHealth and CheckCatalog will return very quickly but executing checks takes longer!
 
-# Perform all checks.  Again, the runner needs the host to test and a provider, we don't need a check ID when running all checks.
-./rodent --runner test-runner ExecuteAllChecks --hostToCheck test01 --provider azure
+# Perform all checks.  Again, the runner needs the host to test and a provider, we don't need a check ID when running all checks.  The --callbackPort only needs to be set if the runner is configured 
+./rodent --runner test-runner ExecuteAllChecks --hostToCheck test01 --provider azure --callbackPort 4000
 # Output will be similar to this:
 # INFO[0016] CheckID 156F64 state is 'passing'            
 # INFO[0022] CheckID 53D035 state is 'passing' 

--- a/cmd/ExecuteAllChecks.go
+++ b/cmd/ExecuteAllChecks.go
@@ -27,6 +27,7 @@ func init() {
 	ExecuteAllChecksCmd.PersistentFlags().StringVarP(&hostToCheck, "hostToCheck", "t", "", "The host that the runner will execute the check on")
 	ExecuteAllChecksCmd.PersistentFlags().StringVarP(&provider, "provider", "p", "default", "The provider the the host runs on. default, aws, gcp and azure are the only supported values, default is the default")
 	ExecuteAllChecksCmd.PersistentFlags().IntVarP(&checkInterval, "checkInterval", "i", 5, "The pause between submitting check requests in seconds, default 5")
+	ExecuteAllChecksCmd.PersistentFlags().UintVar(&callbackPort, "callbackPort", 8000, "The port that the callback listener will use, the default value is 8000")
 
 	err := ExecuteAllChecksCmd.MarkPersistentFlagRequired("hostToCheck")
 	if err != nil {

--- a/cmd/ExecuteCheck.go
+++ b/cmd/ExecuteCheck.go
@@ -9,6 +9,7 @@ import (
 )
 
 var hostToCheck, provider, checkID string
+var callbackPort uint
 
 // ExecuteCheckCmd represents the ExecuteCheck command
 var ExecuteCheckCmd = &cobra.Command{
@@ -28,6 +29,7 @@ func init() {
 	ExecuteCheckCmd.PersistentFlags().StringVarP(&hostToCheck, "hostToCheck", "t", "", "The host that the runner will execute the check on")
 	ExecuteCheckCmd.PersistentFlags().StringVarP(&checkID, "checkID", "c", "", "The ID of the check to be run")
 	ExecuteCheckCmd.PersistentFlags().StringVarP(&provider, "provider", "p", "default", "The provider the the host runs on. default, aws, gcp and azure are the only supported values")
+	ExecuteCheckCmd.PersistentFlags().UintVar(&callbackPort, "callbackPort", 8000, "The port that the callback listener will use, the default value is 8000")
 
 	err := ExecuteCheckCmd.MarkPersistentFlagRequired("hostToCheck")
 	if err != nil {

--- a/cmd/PutFunctions.go
+++ b/cmd/PutFunctions.go
@@ -149,7 +149,8 @@ func WebServer(cbl *CallbackListener) {
 	log.Debug("Starting WebServer")
 	callback := http.HandlerFunc(cbl.CallbackFunc)
 	http.Handle("/api/runner/callbacks", callback)
-	err := http.ListenAndServe(":8000", nil)
+	port := fmt.Sprintf(":%d", callbackPort)
+	err := http.ListenAndServe(port, nil)
 	if err != nil {
 		log.Warn("WebServer Crashed!")
 		log.Fatal(err.Error())


### PR DESCRIPTION
It's not possible to supply a custom port for the callback listener to use.  See README.md in the root of the project for details on how to use.