### PR TITLE
Improved the handling of callbacks

### DIFF
--- a/cmd/types.go
+++ b/cmd/types.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/google/uuid"
 )
@@ -81,4 +82,9 @@ func (c Callback) Print() {
 		os.Exit(1)
 	}
 	fmt.Print(string(cbj))
+}
+
+type ExecuteCatalog struct {
+	ExecuteMap map[uuid.UUID]string
+	sync.Mutex
 }


### PR DESCRIPTION
The callback for a single check includes lots of 'skipped' checks.  The code originally ignored all skipped checks, however, this caused a problem when the invoked check itself was skipped.  The changes to the code record each execution ID along with the check ID and save these as in a global map.  When callbacks are received, the execution ID is used to look up the check ID that the execution ID relates to.  This way, we never lose skipped checks.