### PR TITLE
Add github action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,28 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+
+  workflow_dispatch: 
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build the Docker image
+      run: docker build -t ghcr.io/${{ github.repository_owner }}/rodent:latest .
+
+    - name: docker login
+      run: echo ${{ secrets.ACTIONSECRET }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+    - name: Push image to github registry
+      run:  docker push ghcr.io/${{ github.repository_owner }}/rodent:latest
+
+
+


### PR DESCRIPTION
I now using variables for the repository name and the user (github.actor ).  I however was not able to test it because of the different branch. Even I can see in other projects that they are using  ${{ secrets.GITHUB_TOKEN }} I still have my own action secret name ${{ secrets.ACTIONSECRET }}. So creating a new Action Secret with the same name might be needed.

If this does not work at all, an other idea would be to use the same predefined workflow actions (can be found under https://github.com/actions ) like the trento team used for the runner and the web docker image. 